### PR TITLE
Mark TF2.8 not to be used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['tensorflow >= 2.7.0; python_version >="3.8"',
+requires = ['tensorflow >= 2.7.0,<2.8; python_version >="3.8"',
             'tensorflow <=2.4.4; python_version <"3.8"',
             "setuptools >= 0.53.0"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -708,7 +708,7 @@ install_requires = [
     'funcsigs >= 0.4',
     'futures >= 3.0.5; python_version <= "2.7"',
     'hypercube == 0.3.4',
-    'tensorflow >= 2.7.0; python_version >="3.8"', #ubuntu 20.04 with distro nvcc/gcc
+    'tensorflow >= 2.7.0,<2.8; python_version >="3.8"', #ubuntu 20.04 with distro nvcc/gcc
     'tensorflow <=2.4.4; python_version <"3.8"', #ubuntu 18.04 with distro nvcc/gcc
 ]
 


### PR DESCRIPTION
Cron job failed with numerical errors. There has been a major release of TF in recent days - previously it was working with 2.7.0. WIll mark 2.8 not to be compatible