### PR TITLE
Fix test for existing python 3.8 setup

### DIFF
--- a/.ci/py3.6.docker
+++ b/.ci/py3.6.docker
@@ -151,7 +151,7 @@ RUN python3.6 -m pip install /src/montblanc
 
 # run tests
 RUN python3.6 -m pip install nose simms
-RUN python3.6 -m pip install git+https://github.com/ratt-ru/eidos@a47fa43
+RUN python3.6 -m pip install eidos>=1.1.1
 
 WORKDIR /mb_testing
 RUN mkdir data

--- a/.ci/py3.6.docker
+++ b/.ci/py3.6.docker
@@ -111,7 +111,7 @@ WORKDIR /src
 RUN git clone -b v1.7.2 https://github.com/ska-sa/meqtrees-cattery.git
 RUN git clone -b v1.5.2 https://github.com/ska-sa/purr.git
 RUN git clone -b v1.4.5 https://github.com/ska-sa/kittens.git
-RUN git clone -b v1.7.0 https://github.com/ska-sa/tigger-lsm.git
+RUN git clone -b v1.7.3 https://github.com/ska-sa/tigger-lsm.git
 RUN git clone -b v1.7.4.2 https://github.com/ska-sa/pyxis.git
 RUN git clone -b v1.7.6 https://github.com/ska-sa/owlcat.git
 RUN python3.6 -m pip install ./purr ./owlcat ./kittens ./tigger-lsm

--- a/.ci/py3.8.docker
+++ b/.ci/py3.8.docker
@@ -112,7 +112,7 @@ RUN git clone -b v1.5.2 https://github.com/ska-sa/purr.git
 RUN git clone -b v1.4.5 https://github.com/ska-sa/kittens.git
 RUN git clone -b v1.7.0 https://github.com/ska-sa/tigger-lsm.git
 RUN git clone -b v1.7.4.2 https://github.com/ska-sa/pyxis.git
-RUN git clone -b v1.7.6 https://github.com/ska-sa/owlcat.git
+RUN git clone -b v1.7.9 https://github.com/ska-sa/owlcat.git
 RUN pip3.8 install ./purr ./owlcat ./kittens ./tigger-lsm
 RUN pip3.8 install ./pyxis
 WORKDIR /

--- a/.ci/py3.8.docker
+++ b/.ci/py3.8.docker
@@ -151,7 +151,7 @@ RUN pip3 install /src/montblanc
 
 # run tests
 RUN pip3 install nose simms
-RUN pip3 install git+https://github.com/ratt-ru/eidos@a47fa43
+RUN pip3 install 'eidos>=1.1.1'
 
 WORKDIR /mb_testing
 RUN mkdir data

--- a/.ci/withoutnvcc.py3.8.docker
+++ b/.ci/withoutnvcc.py3.8.docker
@@ -35,7 +35,7 @@ RUN pip3 install /src/montblanc
 
 # run tests
 RUN pip3 install nose simms
-RUN pip3 install git+https://github.com/ratt-ru/eidos@a47fa43
+RUN pip3 install 'eidos>=1.1.1'
 
 WORKDIR /mb_testing
 RUN mkdir data

--- a/montblanc/impl/rime/tensorflow/__init__.py
+++ b/montblanc/impl/rime/tensorflow/__init__.py
@@ -25,9 +25,15 @@ def load_tf_lib():
     from pkg_resources import Requirement
 
     import tensorflow as tf
+    import os
 
     path = pjoin('ext', 'rime.so')
     mbloc = pjoin(working_set.find(Requirement.parse('montblanc')).location, "montblanc")
     rime_lib_path = pjoin(mbloc, path)
+    if not os.path.isfile(rime_lib_path):
+        from montblanc import ext
+        rime_lib_path = os.path.join(os.path.dirname(ext.__file__), 'rime.so')
+    if not os.path.isfile(rime_lib_path):
+        raise RuntimeError("Montblanc backend not found: '{rime_lib_path}'. Have you compiled the backend?")
     return tf.load_op_library(rime_lib_path)
 

--- a/montblanc/impl/rime/tensorflow/rime_ops/test_b_sqrt.py
+++ b/montblanc/impl/rime/tensorflow/rime_ops/test_b_sqrt.py
@@ -129,7 +129,7 @@ class TestBSqrt(unittest.TestCase):
             square[:, :, :, :, :] *= cpu_invert[:, :, :, None, None]
 
             # And we should obtain the brightness matrix
-            assert np.allclose(b_2x2, square)
+            assert np.allclose(b_2x2, square, **tols)
 
             # Compare with GPU bsqrt and invert flag
             for gpu_bsqrt, gpu_invert in S.run(gpu_ops):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['tensorflow >= 2.7.0,<2.8; python_version >="3.8"',
+requires = ['tensorflow >= 2.7.0,<=2.8.4; python_version >="3.8"',
             'tensorflow <=2.4.4; python_version <"3.8"',
             "setuptools >= 0.53.0"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -708,7 +708,7 @@ install_requires = [
     'funcsigs >= 0.4',
     'futures >= 3.0.5; python_version <= "2.7"',
     'hypercube == 0.3.4',
-    'tensorflow >= 2.7.0,<2.8; python_version >="3.8"', #ubuntu 20.04 with distro nvcc/gcc
+    'tensorflow >= 2.7.0,<=2.8.4; python_version >="3.8"', #ubuntu 20.04 with distro nvcc/gcc
     'tensorflow <=2.4.4; python_version <"3.8"', #ubuntu 18.04 with distro nvcc/gcc
 ]
 


### PR DESCRIPTION
This fixes an issue with the upstream eidos package as well as a numerical instability due to incorrect tolerances for single precision in b_sqrt possibly related to #277.